### PR TITLE
Total supply API endpoint updated

### DIFF
--- a/handlers/network.go
+++ b/handlers/network.go
@@ -81,7 +81,7 @@ func Supply(w http.ResponseWriter, r *http.Request) {
 	depositContractBalanceGWei := decimal.NewFromBigInt(new(big.Int).SetBytes(addressMetadata.EthBalance.Balance), 0).DivRound(decimal.NewFromInt(params.GWei), 18)
 
 	// Deposit contract holds 320k LYX lost forever, so we reduce by 320000000000000 GWei
-	totalSupply := (genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther) - (uint64(depositContractBalanceGWei.InexactFloat64()) + uint64(latestBurnData.TotalBurned) + +uint64(320000000000000))
+	totalSupply := (genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther) - (uint64(depositContractBalanceGWei.InexactFloat64()) + uint64(latestBurnData.TotalBurned) + uint64(320000000000000))
 	amount := new(big.Int).Mul(new(big.Int).SetUint64(totalSupply), big.NewInt(params.GWei))
 
 	data := types.SupplyResponse{

--- a/handlers/network.go
+++ b/handlers/network.go
@@ -79,10 +79,9 @@ func Supply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	depositContractBalanceGWei := decimal.NewFromBigInt(new(big.Int).SetBytes(addressMetadata.EthBalance.Balance), 0).DivRound(decimal.NewFromInt(params.GWei), 18)
-	// Deposit contract holds 320k LYX lost forever
-	depositContractFinalBalance := uint64(depositContractBalanceGWei.InexactFloat64()) - 320000000000000
 
-	totalSupply := (genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther) - (depositContractFinalBalance + uint64(latestBurnData.TotalBurned))
+	// Deposit contract holds 320k LYX lost forever, so we reduce by 320000000000000 GWei
+	totalSupply := (genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther) - (uint64(depositContractBalanceGWei.InexactFloat64()) + uint64(latestBurnData.TotalBurned) + +uint64(320000000000000))
 	amount := new(big.Int).Mul(new(big.Int).SetUint64(totalSupply), big.NewInt(params.GWei))
 
 	data := types.SupplyResponse{

--- a/handlers/network.go
+++ b/handlers/network.go
@@ -79,8 +79,10 @@ func Supply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	depositContractBalanceGWei := decimal.NewFromBigInt(new(big.Int).SetBytes(addressMetadata.EthBalance.Balance), 0).DivRound(decimal.NewFromInt(params.GWei), 18)
+	// Deposit contract holds 320k LYX lost forever
+	depositContractFinalBalance := uint64(depositContractBalanceGWei.InexactFloat64()) - 320000000000000
 
-	totalSupply := (genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther) - (uint64(depositContractBalanceGWei.InexactFloat64()) + uint64(latestBurnData.TotalBurned))
+	totalSupply := (genesisTotalSupply + totalAmountWithdrawn + validatorParticipation.EligibleEther) - (depositContractFinalBalance + uint64(latestBurnData.TotalBurned))
 	amount := new(big.Int).Mul(new(big.Int).SetUint64(totalSupply), big.NewInt(params.GWei))
 
 	data := types.SupplyResponse{


### PR DESCRIPTION
This PR reduces deposit contract balance by 320 000 LYX lost forever (sent by staking node operator).